### PR TITLE
Add Windows .tar.gz archives

### DIFF
--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -3,12 +3,18 @@ module VersionsJSONUtil
 using HTTP, JSON, Pkg.BinaryPlatforms, WebCacheUtilities, SHA, Lazy
 import Pkg.BinaryPlatforms: triplet, arch
 
-"Wrapper type to define two jlext methods for portable and installer Windows"
+"Wrapper types to define three jlext methods for portable, tarball and installer Windows"
 struct WindowsPortable
     windows::Windows
 end
 WindowsPortable(arch::Symbol) = WindowsPortable(Windows(arch))
 @forward WindowsPortable.windows (up_os, tar_os, triplet, arch)
+
+struct WindowsTarball
+    windows::Windows
+end
+WindowsTarball(arch::Symbol) = WindowsTarball(Windows(arch))
+@forward WindowsTarball.windows (up_os, tar_os, triplet, arch)
 
 "Wrapper type to define two jlext methods for macOS DMG and macOS tarball"
 struct MacOSTarball
@@ -55,6 +61,7 @@ end
 
 jlext(p::Windows) = "exe"
 jlext(p::WindowsPortable) = "zip"
+jlext(p::WindowsTarball) = "tar.gz"
 jlext(p::MacOS) = "dmg"
 jlext(p) = "tar.gz"
 
@@ -96,6 +103,8 @@ julia_platforms = [
     Windows(:i686),
     WindowsPortable(:x86_64),
     WindowsPortable(:i686),
+    WindowsTarball(:x86_64),
+    WindowsTarball(:i686),
     # *-unknown-freebsd
     FreeBSD(:x86_64),
 ]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Pkg.BinaryPlatforms, JSON
 using VersionsJSONUtil
-import VersionsJSONUtil: WindowsPortable, MacOSTarball
+import VersionsJSONUtil: WindowsPortable, WindowsTarball, MacOSTarball
 using Test
 
 const download_urls = Dict(
@@ -20,6 +20,8 @@ const download_urls = Dict(
         Windows(:i686) =>               "https://julialang-s3.julialang.org/bin/winnt/x86/1.6/julia-1.6.2-win32.exe",
         WindowsPortable(:x86_64) =>     "https://julialang-s3.julialang.org/bin/winnt/x64/1.6/julia-1.6.2-win64.zip",
         WindowsPortable(:i686) =>       "https://julialang-s3.julialang.org/bin/winnt/x86/1.6/julia-1.6.2-win32.zip",
+        WindowsTarball(:x86_64) =>      "https://julialang-s3.julialang.org/bin/winnt/x64/1.6/julia-1.6.2-win64.tar.gz",
+        WindowsTarball(:i686) =>        "https://julialang-s3.julialang.org/bin/winnt/x86/1.6/julia-1.6.2-win32.tar.gz",
         FreeBSD(:x86_64) =>             "https://julialang-s3.julialang.org/bin/freebsd/x64/1.6/julia-1.6.2-freebsd-x86_64.tar.gz",
     ),
 )


### PR DESCRIPTION
This will make it possible for Juliaup to use versions.json.

I am a bit worried, though: this does have the potential to break downstream users if they are currently assuming that there is only on `archive` entry for Windows per version... With this change, there will be two, and the difference is going to be the file extension. Or maybe the idea is that users of versions.json should be written in such a way that this can't cause problems?

~~Creating as a draft for now, until it has finished running on my system and I can check that everything works as intended.~~ EDIT: I ran this branch locally now and the generated `versions.json` looks good to me.