### PR TITLE
Update upload- and download-artifact actions to v4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,7 @@ jobs:
         run: npx -p ajv-cli@3.3.0 ajv -s schema.json -d versions.json
 
       - name: Upload versions.json as workflow artifact
-        uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074
+        uses: actions/upload-artifact@c24449f33cd45d4826c6702db7e49f7cdb9b551d
         with:
           name: versions
           path: versions.json
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Download versions.json from previous job
-        uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: versions
 


### PR DESCRIPTION
The versions of these actions we were using are deprecated, which makes the job fail. This is blocking the 1.11.0-rc4 release.