### PR TITLE
CI: Enable GitHub Merge Queue; also, skip the "full tests" on PR runs, but continue to run them on Merge Queue runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,6 +60,10 @@ jobs:
 
   full-test:
     name: Full test - Julia ${{ matrix.version }}
+    # This job takes a long time (1+ hours).
+    # So we intentionally skip this job on PR runs.
+    # But we still run this job on Merge Queue jobs.
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 360
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,22 +64,17 @@ jobs:
     # So we intentionally skip this job on PR runs.
     # But we still run this job on Merge Queue jobs.
     if: github.event_name != 'pull_request'
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 360
     strategy:
       fail-fast: false
-      matrix:
-        version:
-          - "1.6"
-        os:
-          - ubuntu-latest
 
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - uses: julia-actions/setup-julia@a0a0978e28861c11a3490cee468f87d5b568851a
         with:
-          version: ${{ matrix.version }}
+          version: "1.6"
 
       - uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   package-tests:
-    name: Package tests - Julia ${{ matrix.version }}
+    name: Package tests
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -59,7 +59,7 @@ jobs:
       - uses: julia-actions/julia-runtest@eda4346d69c0d1653e483c397a83c7f32f4ef2ac
 
   full-test:
-    name: Full test - Julia ${{ matrix.version }}
+    name: Full test
     # This job takes a long time (1+ hours).
     # So we intentionally skip this job on PR runs.
     # But we still run this job on Merge Queue jobs.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - "README.md"
   pull_request:
+  merge_group: # GitHub Merge Queue
 
 concurrency:
   # Skip intermediate builds: all builds except for builds on the `master` branch


### PR DESCRIPTION
Includes:
- #22 