### PR TITLE
CI: Skip the "full tests" on PR runs, but continue to run them on Merge Queue runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,6 +60,10 @@ jobs:
 
   full-test:
     name: Full test - Julia ${{ matrix.version }}
+    # This job takes a long time (1+ hours).
+    # So we intentionally skip this job on PR runs.
+    # But we still run this job on Merge Queue jobs.
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 360
     strategy:


### PR DESCRIPTION
Depends on:
- #19 