### PR TITLE
add lts field

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,7 @@ permissions:
 env:
   aws_region: us-east-1
   s3_bucket: julialang2
+  JULIA_LTS: '1.10'
 
 jobs:
   package-tests:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,8 @@ permissions:
 env:
   aws_region: us-east-1
   s3_bucket: julialang2
-  JULIA_LTS: '1.10'
+  JULIA_LTS: '1.0 1.6 1.10'
+  
 
 jobs:
   package-tests:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ More info: https://github.com/JuliaLang/julia/issues/33817
 To trigger a rebuild of the `versions.json` file and to upload it to S3, you need to manually trigger the `CI` workflow in this repo.
 You can either trigger it through the GitHub UI or via an authenticated HTTP request.
 
-### Set LTS tag
+### Setting the LTS field
 
-The current Julia LTS version is set via the `JULIA_LTS` variable in the [CI workflow](.github/workflows/CI.yml).
+Julia LTS versions are set via the `JULIA_LTS` variable in the [CI workflow](.github/workflows/CI.yml).
 
 ### GitHub's UI
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ More info: https://github.com/JuliaLang/julia/issues/33817
 To trigger a rebuild of the `versions.json` file and to upload it to S3, you need to manually trigger the `CI` workflow in this repo.
 You can either trigger it through the GitHub UI or via an authenticated HTTP request.
 
+### Set LTS tag
+
+The current Julia LTS version is set via the `JULIA_LTS` variable in the [CI workflow](.github/workflows/CI.yml).
+
 ### GitHub's UI
 
 ![grafik](https://user-images.githubusercontent.com/20866761/127783220-fd8167db-5051-4a18-b70a-ea42085a7cb5.png)

--- a/schema.json
+++ b/schema.json
@@ -17,6 +17,9 @@
                 },
                 "stable": {
                     "type": "boolean"
+                },
+                "lts": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -140,6 +140,7 @@ end
 function main(out_path)
     tags = get_tags()
     tag_versions = filter(x -> x !== nothing, [vnum_maybe(basename(t["ref"])) for t in tags])
+    
     meta = Dict()
     number_urls_tried = 0
     number_urls_success = 0

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -122,6 +122,11 @@ function is_stable(v::VersionNumber)
     return v.prerelease == () && v.build == ()
 end
 
+function is_lts(v::VersionNumber)
+    lts = VersionNumber(ENV["JULIA_LTS"])
+    return lts.major === v.major && lts.minor === v.minor && isempty(v.prerelease)
+end
+
 # Get list of tags from the Julia repo
 function get_tags()
     @info("Probing for tag list...")
@@ -135,7 +140,6 @@ end
 function main(out_path)
     tags = get_tags()
     tag_versions = filter(x -> x !== nothing, [vnum_maybe(basename(t["ref"])) for t in tags])
-
     meta = Dict()
     number_urls_tried = 0
     number_urls_success = 0
@@ -173,6 +177,7 @@ function main(out_path)
             if !haskey(meta, version)
                 meta[version] = Dict(
                     "stable" => is_stable(version),
+                    "lts" => is_lts(version),
                     "files" => Vector{Dict}(),
                 )
             end

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -123,8 +123,8 @@ function is_stable(v::VersionNumber)
 end
 
 function is_lts(v::VersionNumber)
-    lts = VersionNumber(ENV["JULIA_LTS"])
-    return lts.major === v.major && lts.minor === v.minor && isempty(v.prerelease)
+    lts_list = VersionNumber.(split(ENV["JULIA_LTS"], " "))
+    return any(lts -> lts.major === v.major && lts.minor === v.minor && isempty(v.prerelease), lts_list)
 end
 
 # Get list of tags from the Julia repo


### PR DESCRIPTION
Add an "lts" field to each tag in the JSON release feed. This is set via the JULIA_LTS variable in the CI workflow, which only requires that the major and minor version numbers match (no need to manually set for every patch release). Tested locally with LocalStack. 

This is a follow-up attempt from #32 which broke the [Buildkite plugin](https://github.com/JuliaCI/julia-buildkite-plugin/blob/b4d0bfa510bc399417133adae013385af5c71190/hooks/expand-major-only.py#L23C1-L23C98). It was thereafter decided to simply include lts tagging as a new field for each release tag, rather than it be its own tag. It will be up to downstream consumers to select the most recent lts release, since every patch release for the given version will possess `"lts": true`.

Closes #2 

@IanButterworth @DilumAluthge 