### PR TITLE
Throw a fatal error if we are unable to download the binary for a Tier 1 platform

### DIFF
--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -139,6 +139,11 @@ end
 
 platform_is_tier_1(platform::Any, version::VersionNumber) = platform_is_tier_1(platform.p, version)
 function platform_is_tier_1(p::Platform, version::VersionNumber)
+    # For super old Julia versions, we just return false
+    # This is because super old Julia versions didn't always conform to the same naming convention for S3 downloads
+    if version < v"0.4.0-" # TODO: Figure out how tight to make this bound
+        return false
+    end
     tier1_list = [
         # These are always Tier 1, regardless of the Julia version:
         Platform("x86_64", "linux"; libc = "glibc"),
@@ -178,7 +183,7 @@ function main(out_path)
                 end
                 if platform_is_tier_1(platform, version)
                     msg = "Unable to download binary for Tier 1 platform; this error is fatal"
-                    @error msg platform version
+                    @error msg platform version url
                     rethrow()
                 end
                 println(stdout, " ✗")

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -176,7 +176,7 @@ function main(out_path)
                 if isa(ex, InterruptException)
                     rethrow()
                 end
-                if platform_is_tier_1(platform, version::VersionNumber)
+                if platform_is_tier_1(platform, version)
                     msg = "Unable to download binary for Tier 1 platform; this error is fatal"
                     @error msg platform version
                     rethrow()

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -132,6 +132,25 @@ function get_tags()
     JSON.parse(String(read(tags_json_path)))
 end
 
+# Like `in`, but enforces that types match
+function typed_in(x::T, s::Set{T}) where {T}
+    return x in s
+end
+
+platform_is_tier_1(platform::Any, version::VersionNumber) = platform_is_tier_1(platform.p, version)
+function platform_is_tier_1(p::Platform, version::VersionNumber)
+    tier1_list = [
+        Platform("x86_64", "linux"; libc = "glibc"),
+        Platform("x86_64", "windows"),
+    ]
+    if version >= v"1.10-" # TODO: Fix this bound (I think it can be lower than 1.10)
+        apple_silicon = Platform("aarch64", "macos")
+        push!(tier1_list, apple_silicon)
+    end
+    return typed_in(p, tier1_list)
+end
+
+
 function main(out_path)
     tags = get_tags()
     tag_versions = filter(x -> x !== nothing, [vnum_maybe(basename(t["ref"])) for t in tags])
@@ -152,7 +171,12 @@ function main(out_path)
                 filepath = WebCacheUtilities.download_to_cache(filename, url)
             catch ex
                 if isa(ex, InterruptException)
-                    rethrow(ex)
+                    rethrow()
+                end
+                if platform_is_tier_1(platform, version::VersionNumber)
+                    msg = "Unable to download binary for Tier 1 Platform; this error is fatal" platform version
+                    @error msg platform version
+                    rethrow()
                 end
                 println(stdout, " ✗")
                 continue
@@ -188,7 +212,7 @@ function main(out_path)
                     println(stdout, " ✓")
                 catch ex
                     if isa(ex, InterruptException)
-                        rethrow(ex)
+                        rethrow()
                     end
                     println(stdout, " ✗")
                 end

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -177,7 +177,7 @@ function main(out_path)
                     rethrow()
                 end
                 if platform_is_tier_1(platform, version::VersionNumber)
-                    msg = "Unable to download binary for Tier 1 Platform; this error is fatal" platform version
+                    msg = "Unable to download binary for Tier 1 platform; this error is fatal"
                     @error msg platform version
                     rethrow()
                 end

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -142,7 +142,7 @@ platform_is_tier_1(x::Any, version::VersionNumber) = platform_is_tier_1(extract_
 function platform_is_tier_1(p::Platform, version::VersionNumber)
     # For super old Julia versions, we just return false
     # This is because super old Julia versions didn't always conform to the same naming convention for S3 downloads
-    if version < v"0.4.0-"
+    if version < v"0.5.0"
         return false
     end
     tier1_list = [

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -8,20 +8,20 @@ struct WindowsPortable
     windows::Windows
 end
 WindowsPortable(arch::Symbol) = WindowsPortable(Windows(arch))
-@forward WindowsPortable.windows (up_os, tar_os, triplet, arch)
+@forward WindowsPortable.windows (up_os, tar_os, triplet, arch, extract_platform)
 
 struct WindowsTarball
     windows::Windows
 end
 WindowsTarball(arch::Symbol) = WindowsTarball(Windows(arch))
-@forward WindowsTarball.windows (up_os, tar_os, triplet, arch)
+@forward WindowsTarball.windows (up_os, tar_os, triplet, arch, extract_platform)
 
 "Wrapper type to define two jlext methods for macOS DMG and macOS tarball"
 struct MacOSTarball
     macos::MacOS
 end
 MacOSTarball(arch::Symbol) = MacOSTarball(MacOS(arch))
-@forward MacOSTarball.macos (up_os, tar_os, triplet, arch)
+@forward MacOSTarball.macos (up_os, tar_os, triplet, arch, extract_platform)
 
 up_os(p::Windows) = "winnt"
 up_os(p::MacOS) = "mac"
@@ -137,11 +137,12 @@ function typed_in(x::T, collection::Vector{T}) where {T}
     return x in collection
 end
 
-platform_is_tier_1(platform::Any, version::VersionNumber) = platform_is_tier_1(platform.p, version)
+extract_platform(x::Base.BinaryPlatforms.AbstractPlatform) = (x.p)::Platform
+platform_is_tier_1(x::Any, version::VersionNumber) = platform_is_tier_1(extract_platform(x), version)
 function platform_is_tier_1(p::Platform, version::VersionNumber)
     # For super old Julia versions, we just return false
     # This is because super old Julia versions didn't always conform to the same naming convention for S3 downloads
-    if version < v"0.4.0-" # TODO: Figure out how tight to make this bound
+    if version < v"0.4.0-"
         return false
     end
     tier1_list = [

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -144,7 +144,7 @@ function platform_is_tier_1(p::Platform, version::VersionNumber)
         Platform("x86_64", "linux"; libc = "glibc"),
         Platform("x86_64", "windows"),
     ]
-    if version >= v"1.10-" # TODO: Fix this bound (I think it can be lower than 1.10)
+    if version >= v"1.7.0-beta3"
         # macOS Apple Silicon is only a Tier 1 for newer Julia versions
         # Older Julia versions don't have native builds for Apple Silicon
         apple_silicon = Platform("aarch64", "macos")

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -140,9 +140,10 @@ end
 extract_platform(x::Base.BinaryPlatforms.AbstractPlatform) = (x.p)::Platform
 platform_is_tier_1(x::Any, version::VersionNumber) = platform_is_tier_1(extract_platform(x), version)
 function platform_is_tier_1(p::Platform, version::VersionNumber)
-    # For super old Julia versions, we just return false
-    # This is because super old Julia versions didn't always conform to the same naming convention for S3 downloads
-    if version < v"0.5.0"
+    # For older Julia versions (prior to 1.0.0), we just return false
+    # This is because older Julia versions didn't always conform to the same naming convention for S3 downloads
+    # And e.g. tarballs didn't always exist for all platforms
+    if version < v"1.0.0"
         return false
     end
     tier1_list = [

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -133,17 +133,20 @@ function get_tags()
 end
 
 # Like `in`, but enforces that types match
-function typed_in(x::T, s::Set{T}) where {T}
-    return x in s
+function typed_in(x::T, collection::Vector{T}) where {T}
+    return x in collection
 end
 
 platform_is_tier_1(platform::Any, version::VersionNumber) = platform_is_tier_1(platform.p, version)
 function platform_is_tier_1(p::Platform, version::VersionNumber)
     tier1_list = [
+        # These are always Tier 1, regardless of the Julia version:
         Platform("x86_64", "linux"; libc = "glibc"),
         Platform("x86_64", "windows"),
     ]
     if version >= v"1.10-" # TODO: Fix this bound (I think it can be lower than 1.10)
+        # macOS Apple Silicon is only a Tier 1 for newer Julia versions
+        # Older Julia versions don't have native builds for Apple Silicon
         apple_silicon = Platform("aarch64", "macos")
         push!(tier1_list, apple_silicon)
     end


### PR DESCRIPTION
This is intended to add some safeguards that help us detect #49.