### PR TITLE
CI: Bump `actions/upload-artifact` from 4.6.0 to 7.0.0 and `actions/download-artifact` from 4.1.8 to 8.0.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Download versions.json from previous job
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: versions
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,7 @@ jobs:
       - run: julia --project test/more_tests.jl versions.json
 
       - name: Upload versions.json as workflow artifact
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: versions
           path: versions.json

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Download versions.json from previous job
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: versions
 


### PR DESCRIPTION
If I recall correctly, these two actions should be bumped together, not separately.

So this PR bumps both actions (upload and download) to their latest versions.