### PR TITLE
Record `ETag` and `Last-Modified` for each URL

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.11"
 manifest_format = "2.0"
-project_hash = "297ab27881cec0a85c719648b28381580e85162c"
+project_hash = "1faf98ec23df19c842aa27dbea894b9ec5b8c027"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 WebCacheUtilities = "0c1c26de-fc5f-47ff-87a8-a157289a9bac"
 
 [compat]

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -4,6 +4,7 @@ using HTTP, JSON, Pkg.BinaryPlatforms, WebCacheUtilities, SHA, Lazy
 using Tar: Tar
 import Pkg.BinaryPlatforms: triplet, arch
 import Pkg.PlatformEngines: exe7z
+using URIs: URIs, URI
 
 "Wrapper types to define three jlext methods for portable, tarball and installer Windows"
 struct WindowsPortable
@@ -143,6 +144,31 @@ function get_tags()
     JSON.parse(String(read(tags_json_path)))
 end
 
+##### --------------------------------------------------------------------------------------
+##### Get ETag and Last-Modified, so we know if we need to re-download and re-checksum files
+
+Base.@kwdef struct HeadInfo
+    url::URI
+    etag::Union{String, Nothing}
+    last_modified::Union{String, Nothing}
+end
+
+function HeadInfo(url)
+    local response = nothing
+    try
+        response = HTTP.head(url)
+    catch
+        error("Encountered error when making HEAD request to URL: $url")
+    end
+    etag = HTTP.header(response, "ETag", nothing)
+    etag === nothing && @warn "ETag not provided in response from $url"
+    last_modified = HTTP.header(response, "Last-Modified", nothing)
+    last_modified === nothing && @warn "Last-Modified not provided in response from $url"
+    return HeadInfo(; url=URI(url), etag, last_modified)
+end
+
+##### --------------------------------------------------------------------------------------
+
 function main(out_path)
     tags = get_tags()
     tag_versions = filter(x -> x !== nothing, [vnum_maybe(basename(t["ref"])) for t in tags])
@@ -240,6 +266,8 @@ function main(out_path)
 
             end
 
+            headinfo = HeadInfo(url)
+
             # Build up metadata about this file
             file_dict = Dict(
                 "triplet" => triplet(platform),
@@ -258,6 +286,13 @@ function main(out_path)
             # Add in `.asc` signature content, if applicable
             if asc_signature !== nothing
                 file_dict["asc"] = asc_signature
+            end
+
+            if !isnothing(headinfo.etag)
+                file_dict["etag"] = headinfo.etag
+            end
+            if !isnothing(headinfo.last_modified)
+                file_dict["last-modified"] = headinfo.last_modified
             end
 
             # Right now, all we have are archives, but let's be forward-thinking

--- a/test/more_tests.jl
+++ b/test/more_tests.jl
@@ -67,8 +67,10 @@ end
                     ]
                     optional_keys = [
                         "asc",
+                        "etag",
                         "git-tree-sha1",
                         "git-tree-sha256",
+                        "last-modified",
                     ]
                     allowed_keys = union(required_keys, optional_keys)
                     @test required_keys ⊆ collect(keys(filedict))


### PR DESCRIPTION
This is needed for #67. We need the `ETag` and `Last-Modified` to determine whether the information we have is fresh or stale.

Cross-ref: #51

hat-tip: @ararslan, who suggested using `ETag` and `Last-Modified`, because we use S3.