### PR TITLE
Revert "Add `git-tree-{sha1,sha256}` (but only for `.tar.gz` downloads)"

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.11"
 manifest_format = "2.0"
-project_hash = "297ab27881cec0a85c719648b28381580e85162c"
+project_hash = "55efac5eb5e37942e9cd8fef54ac706b62080e7c"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,6 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Lazy = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 WebCacheUtilities = "0c1c26de-fc5f-47ff-87a8-a157289a9bac"
 

--- a/schema.json
+++ b/schema.json
@@ -41,12 +41,6 @@
                 "sha256": {
                     "type": "string"
                 },
-                "git-tree-sha1": {
-                    "type": "string"
-                },
-                "git-tree-sha256": {
-                    "type": "string"
-                },
                 "size": {
                     "type": "integer"
                 },

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -1,9 +1,7 @@
 module VersionsJSONUtil
 
 using HTTP, JSON, Pkg.BinaryPlatforms, WebCacheUtilities, SHA, Lazy
-using Tar: Tar
 import Pkg.BinaryPlatforms: triplet, arch
-import Pkg.PlatformEngines: exe7z
 
 "Wrapper types to define three jlext methods for portable, tarball and installer Windows"
 struct WindowsPortable
@@ -111,11 +109,6 @@ julia_platforms = [
     FreeBSD(:x86_64),
 ]
 
-const tarball_git_tree_hash_skiplist = [
-    # Corrupt gzip stream: `7z` reports a CRC failure for the embedded tarball.
-    "https://julialang-s3.julialang.org/bin/linux/x86/0.7/julia-0.7.0-alpha-linux-i686.tar.gz",
-]
-
 function vnum_maybe(x::AbstractString)
     try
         return VersionNumber(x)
@@ -127,10 +120,6 @@ end
 
 function is_stable(v::VersionNumber)
     return v.prerelease == () && v.build == ()
-end
-
-function tarball_git_tree_hash(; tarball_path::AbstractString, algorithm::AbstractString)
-    return open(io -> Tar.tree_hash(io; algorithm), `$(exe7z()) x $tarball_path -so`)
 end
 
 # Get list of tags from the Julia repo
@@ -171,22 +160,6 @@ function main(out_path)
             number_urls_success += 1
             println(stdout, " ✓")
 
-            if endswith(filename, ".dmg")
-                kind = "archive"
-                extension = "dmg"
-            elseif endswith(filename, ".exe")
-                kind = "installer"
-                extension = "exe"
-            elseif endswith(filename, ".tar.gz")
-                kind = "archive"
-                extension = "tar.gz"
-            elseif endswith(filename, ".zip")
-                kind = "archive"
-                extension = "zip"
-            else
-                error("Unsupported file extension in filename: $(filename)")
-            end
-
             tarball_hash_path = hit_file_cache("$(filename).sha256") do tarball_hash_path
                 open(filepath, "r") do io
                     open(tarball_hash_path, "w") do hash_io
@@ -195,24 +168,6 @@ function main(out_path)
                 end
             end
             tarball_hash = String(read(tarball_hash_path))
-
-            if extension == "tar.gz" && !(url in tarball_git_tree_hash_skiplist)
-                tarball_git_tree_hashes = Dict{String, String}()
-                tree_hash_path_sha1 = hit_file_cache("$(filename).git-tree-sha1") do tree_hash_path
-                    open(tree_hash_path, "w") do hash_io
-                        write(hash_io, tarball_git_tree_hash(; tarball_path=filepath, algorithm="git-sha1"))
-                    end
-                end
-                tree_hash_path_sha256 = hit_file_cache("$(filename).git-tree-sha256") do tree_hash_path
-                    open(tree_hash_path, "w") do hash_io
-                        write(hash_io, tarball_git_tree_hash(; tarball_path=filepath, algorithm="git-sha256"))
-                    end
-                end
-                tarball_git_tree_hashes["git-tree-sha1"] = String(read(tree_hash_path_sha1))
-                tarball_git_tree_hashes["git-tree-sha256"] = String(read(tree_hash_path_sha256))
-            else
-                tarball_git_tree_hashes = nothing
-            end
 
             # Initialize overall version key, if needed
             if !haskey(meta, version)
@@ -241,6 +196,21 @@ function main(out_path)
             end
 
             # Build up metadata about this file
+            if endswith(filename, ".dmg")
+                kind = "archive"
+                extension = "dmg"
+            elseif endswith(filename, ".exe")
+                kind = "installer"
+                extension = "exe"
+            elseif endswith(filename, ".tar.gz")
+                kind = "archive"
+                extension = "tar.gz"
+            elseif endswith(filename, ".zip")
+                kind = "archive"
+                extension = "zip"
+            else
+                error("Unsupported file extension in filename: $(filename)")
+            end
             file_dict = Dict(
                 "triplet" => triplet(platform),
                 "os" => meta_os(platform),
@@ -252,9 +222,6 @@ function main(out_path)
                 "extension" => extension,
                 "url" => url,
             )
-            if tarball_git_tree_hashes !== nothing
-                merge!(file_dict, tarball_git_tree_hashes)
-            end
             # Add in `.asc` signature content, if applicable
             if asc_signature !== nothing
                 file_dict["asc"] = asc_signature

--- a/test/more_tests.jl
+++ b/test/more_tests.jl
@@ -67,6 +67,8 @@ end
                     ]
                     optional_keys = [
                         "asc",
+                        "git-tree-sha1",
+                        "git-tree-sha256",
                     ]
                     allowed_keys = union(required_keys, optional_keys)
                     @test required_keys ⊆ collect(keys(filedict))

--- a/test/more_tests.jl
+++ b/test/more_tests.jl
@@ -67,8 +67,6 @@ end
                     ]
                     optional_keys = [
                         "asc",
-                        "git-tree-sha1",
-                        "git-tree-sha256",
                     ]
                     allowed_keys = union(required_keys, optional_keys)
                     @test required_keys ⊆ collect(keys(filedict))


### PR DESCRIPTION
Reverts JuliaLang/VersionsJSONUtil.jl#64

This is only a temporary revert. Computing treehashes takes a long time, and now our build times are hitting GitHub's 6 hour time limit. So let's revert for now.

Once #67 has been merged, I'll reland this, because build times should be much better at that point.