### PR TITLE
Allow `etag` and `last-modified` as optional fields

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -47,6 +47,12 @@
                 "git-tree-sha256": {
                     "type": "string"
                 },
+                "etag": {
+                    "type": "string"
+                },
+                "last-modified": {
+                    "type": "string"
+                },
                 "size": {
                     "type": "integer"
                 },

--- a/test/more_tests.jl
+++ b/test/more_tests.jl
@@ -67,8 +67,10 @@ end
                     ]
                     optional_keys = [
                         "asc",
+                        "etag",
                         "git-tree-sha1",
                         "git-tree-sha256",
+                        "last-modified",
                     ]
                     allowed_keys = union(required_keys, optional_keys)
                     @test required_keys ⊆ collect(keys(filedict))


### PR DESCRIPTION
- Allow optional `etag` and `last-modified` fields in `File` objects in `schema.json`.
- Allow those same optional fields in `test/more_tests.jl`.

This is preparation for https://github.com/JuliaLang/VersionsJSONUtil.jl/pull/76.

Cross-ref: #51

🤖 Generated by OpenAI Codex.
