### PR TITLE
`schema.json`: Add pattern constraints to supplement the existing `qt-uri-protocols` and `qt-uri-extensions` constraints

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -149,5 +149,7 @@ jobs:
         run: rm -fv versions.json
       - name: Download the current versions.json from S3
         run: curl -LO https://julialang-s3.julialang.org/bin/versions.json
+      - name: Validate versions.json against schema
+        run: npx -p ajv-cli@3.3.0 ajv -s schema.json -d versions.json
       - name: Run the post-build tests on the versions.json that we downloaded from S3
         run: julia --project test/more_tests.jl versions.json

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,8 +94,16 @@ jobs:
           path: versions.json
           if-no-files-found: error
 
+  schema-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - run: npx -p ajv-cli@3.3.0 ajv compile -s schema.json
+
   upload-to-s3:
-    needs: [package-tests, full-test]
+    needs: [package-tests, full-test, schema-check]
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/schema.json
+++ b/schema.json
@@ -67,6 +67,14 @@
                         ".exe",
                         ".gz",
                         ".zip"
+                    ],
+                    "allOf": [
+                        {
+                            "pattern": "^https://"
+                        },
+                        {
+                            "pattern": "\\.(?:dmg|exe|gz|zip)$"
+                        }
                     ]
                 },
                 "asc": {


### PR DESCRIPTION
Prior to this PR, our JSON schema uses `qt-uri-protocols` and `qt-uri-extensions`. However, if I understand correctly, those are non-standard, and validators won't necessarily check them.

So this PR adds some pattern (regex) constraints to check the same things that `qt-uri-protocols` and `qt-uri-extensions`. I belive that most validators will check the pattern constraints.

We keep `qt-uri-protocols` and `qt-uri-extensions`, because they might still be useful if your validator supports them.

This branch builds on top of PR #82.

🤖 Generated by OpenAI Codex.
