### PR TITLE
CI: In the `test-current-s3` CI job, validate the downloaded `versions.json` against the schema

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -141,5 +141,7 @@ jobs:
         run: rm -fv versions.json
       - name: Download the current versions.json from S3
         run: curl -LO https://julialang-s3.julialang.org/bin/versions.json
+      - name: Validate versions.json against schema
+        run: npx -p ajv-cli@3.3.0 ajv -s schema.json -d versions.json
       - name: Run the post-build tests on the versions.json that we downloaded from S3
         run: julia --project test/more_tests.jl versions.json


### PR DESCRIPTION
This helps gives us more confidence that schema changes we make won't cause breakage against the `versions.json` that is currently deployed to S3.

🤖 Generated by OpenAI Codex.
