### PR TITLE
[codex] Tighten versions.json schema constraints

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -149,5 +149,7 @@ jobs:
         run: rm -fv versions.json
       - name: Download the current versions.json from S3
         run: curl -LO https://julialang-s3.julialang.org/bin/versions.json
+      - name: Validate versions.json against schema
+        run: npx -p ajv-cli@3.3.0 ajv -s schema.json -d versions.json
       - name: Run the post-build tests on the versions.json that we downloaded from S3
         run: julia --project test/more_tests.jl versions.json

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,8 +94,16 @@ jobs:
           path: versions.json
           if-no-files-found: error
 
+  schema-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - run: npx -p ajv-cli@3.3.0 ajv compile -s schema.json
+
   upload-to-s3:
-    needs: [package-tests, full-test]
+    needs: [package-tests, full-test, schema-check]
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/schema.json
+++ b/schema.json
@@ -16,6 +16,17 @@
                     }
                 }
             }
+        },
+        {
+            "patternProperties": {
+                "^[0-9]+\\.[0-9]+\\.[0-9]+$": {
+                    "properties": {
+                        "stable": {
+                            "const": true
+                        }
+                    }
+                }
+            }
         }
     ],
     "additionalProperties": {

--- a/schema.json
+++ b/schema.json
@@ -240,6 +240,72 @@
                             }
                         }
                     ]
+                },
+                {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "arch": {
+                                    "const": "x86_64"
+                                },
+                                "triplet": {
+                                    "enum": [
+                                        "x86_64-apple-darwin14",
+                                        "x86_64-w64-mingw32",
+                                        "x86_64-linux-gnu",
+                                        "x86_64-unknown-freebsd11.1",
+                                        "x86_64-linux-musl"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "arch": {
+                                    "const": "i686"
+                                },
+                                "triplet": {
+                                    "enum": [
+                                        "i686-w64-mingw32",
+                                        "i686-linux-gnu"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "arch": {
+                                    "const": "powerpc64le"
+                                },
+                                "triplet": {
+                                    "const": "powerpc64le-linux-gnu"
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "arch": {
+                                    "const": "aarch64"
+                                },
+                                "triplet": {
+                                    "enum": [
+                                        "aarch64-linux-gnu",
+                                        "aarch64-apple-darwin14"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "arch": {
+                                    "const": "armv7l"
+                                },
+                                "triplet": {
+                                    "const": "armv7l-linux-gnueabihf"
+                                }
+                            }
+                        }
+                    ]
                 }
             ],
             "title": "File"

--- a/schema.json
+++ b/schema.json
@@ -54,7 +54,8 @@
                     "type": "integer"
                 },
                 "version": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-(?:alpha[0-9]*|beta[0-9]*|rc[0-9]+|pre\\.(?:alpha|beta)))?$"
                 },
                 "os": {
                     "$ref": "#/definitions/OS"

--- a/schema.json
+++ b/schema.json
@@ -43,7 +43,8 @@
                     "pattern": "^[0-9A-Fa-f]{64}$"
                 },
                 "git-tree-sha1": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^[0-9A-Fa-f]{40}$"
                 },
                 "git-tree-sha256": {
                     "type": "string"

--- a/schema.json
+++ b/schema.json
@@ -80,7 +80,7 @@
                             "pattern": "^https://"
                         },
                         {
-                            "pattern": "\\.(?:dmg|exe|gz|zip)$"
+                            "pattern": "\\.(?:dmg|exe|tar\\.gz|zip)$"
                         }
                     ]
                 },

--- a/schema.json
+++ b/schema.json
@@ -85,7 +85,8 @@
                     ]
                 },
                 "asc": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^-----BEGIN PGP SIGNATURE-----\\n(?:[A-Za-z0-9-]+: [^\\n]*\\n)*\\n(?:[A-Za-z0-9+/]{1,76}=*\\n)+=[A-Za-z0-9+/]{4}\\n-----END PGP SIGNATURE-----\\n?$"
                 },
                 "extension": {
                     "$ref": "#/definitions/FileExtension"

--- a/schema.json
+++ b/schema.json
@@ -14,6 +14,7 @@
             "properties": {
                 "files": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "$ref": "#/definitions/File"
                     }

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,9 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "type": "object",
+    "propertyNames": {
+        "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-(?:alpha[0-9]*|beta[0-9]*|rc[0-9]+|pre\\.(?:alpha|beta)))?$"
+    },
     "additionalProperties": {
         "$ref": "#/definitions/WelcomeValue"
     },

--- a/schema.json
+++ b/schema.json
@@ -5,6 +5,19 @@
     "propertyNames": {
         "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-(?:alpha[0-9]*|beta[0-9]*|rc[0-9]+|pre\\.(?:alpha|beta)))?$"
     },
+    "allOf": [
+        {
+            "patternProperties": {
+                "^[0-9]+\\.[0-9]+\\.[0-9]+-(?:alpha[0-9]*|beta[0-9]*|rc[0-9]+|pre\\.(?:alpha|beta))$": {
+                    "properties": {
+                        "stable": {
+                            "const": false
+                        }
+                    }
+                }
+            }
+        }
+    ],
     "additionalProperties": {
         "$ref": "#/definitions/WelcomeValue"
     },

--- a/schema.json
+++ b/schema.json
@@ -16,6 +16,7 @@
                 "files": {
                     "type": "array",
                     "minItems": 1,
+                    "uniqueItems": true,
                     "items": {
                         "$ref": "#/definitions/File"
                     }

--- a/schema.json
+++ b/schema.json
@@ -72,7 +72,7 @@
                     "qt-uri-extensions": [
                         ".dmg",
                         ".exe",
-                        ".gz",
+                        ".tar.gz",
                         ".zip"
                     ],
                     "allOf": [

--- a/schema.json
+++ b/schema.json
@@ -39,7 +39,8 @@
                     "$ref": "#/definitions/Arch"
                 },
                 "sha256": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^[0-9A-Fa-f]{64}$"
                 },
                 "git-tree-sha1": {
                     "type": "string"

--- a/schema.json
+++ b/schema.json
@@ -54,7 +54,8 @@
                     "pattern": "^[0-9A-Fa-f]{64}$"
                 },
                 "size": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 1
                 },
                 "version": {
                     "type": "string",

--- a/schema.json
+++ b/schema.json
@@ -86,6 +86,7 @@
                 },
                 "asc": {
                     "type": "string",
+                    "minLength": 1,
                     "pattern": "^-----BEGIN PGP SIGNATURE-----\\n(?:[A-Za-z0-9-]+: [^\\n]*\\n)*\\n(?:[A-Za-z0-9+/]{1,76}=*\\n)+=[A-Za-z0-9+/]{4}\\n-----END PGP SIGNATURE-----\\n?$"
                 },
                 "extension": {

--- a/schema.json
+++ b/schema.json
@@ -83,7 +83,7 @@
                             "pattern": "^https://\\S+$"
                         },
                         {
-                            "pattern": "\\.(?:dmg|exe|tar\\.gz|zip)$"
+                            "pattern": "/[^/?#]+\\.(?:dmg|exe|tar\\.gz|zip)$"
                         }
                     ]
                 },

--- a/schema.json
+++ b/schema.json
@@ -111,6 +111,52 @@
                 "url",
                 "version"
             ],
+            "allOf": [
+                {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "extension": {
+                                    "const": "dmg"
+                                },
+                                "url": {
+                                    "pattern": "\\.dmg$"
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "extension": {
+                                    "const": "exe"
+                                },
+                                "url": {
+                                    "pattern": "\\.exe$"
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "extension": {
+                                    "const": "tar.gz"
+                                },
+                                "url": {
+                                    "pattern": "\\.tar\\.gz$"
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "extension": {
+                                    "const": "zip"
+                                },
+                                "url": {
+                                    "pattern": "\\.zip$"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
             "title": "File"
         },
         "Arch": {

--- a/schema.json
+++ b/schema.json
@@ -155,6 +155,34 @@
                             }
                         }
                     ]
+                },
+                {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "kind": {
+                                    "const": "installer"
+                                },
+                                "extension": {
+                                    "const": "exe"
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "kind": {
+                                    "const": "archive"
+                                },
+                                "extension": {
+                                    "enum": [
+                                        "dmg",
+                                        "tar.gz",
+                                        "zip"
+                                    ]
+                                }
+                            }
+                        }
+                    ]
                 }
             ],
             "title": "File"

--- a/schema.json
+++ b/schema.json
@@ -77,7 +77,7 @@
                     ],
                     "allOf": [
                         {
-                            "pattern": "^https://"
+                            "pattern": "^https://[^/?#]+/"
                         },
                         {
                             "pattern": "\\.(?:dmg|exe|tar\\.gz|zip)$"

--- a/schema.json
+++ b/schema.json
@@ -183,6 +183,63 @@
                             }
                         }
                     ]
+                },
+                {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "os": {
+                                    "const": "mac"
+                                },
+                                "triplet": {
+                                    "enum": [
+                                        "x86_64-apple-darwin14",
+                                        "aarch64-apple-darwin14"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "os": {
+                                    "const": "winnt"
+                                },
+                                "triplet": {
+                                    "enum": [
+                                        "x86_64-w64-mingw32",
+                                        "i686-w64-mingw32"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "os": {
+                                    "const": "linux"
+                                },
+                                "triplet": {
+                                    "enum": [
+                                        "x86_64-linux-gnu",
+                                        "i686-linux-gnu",
+                                        "powerpc64le-linux-gnu",
+                                        "aarch64-linux-gnu",
+                                        "armv7l-linux-gnueabihf",
+                                        "x86_64-linux-musl"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "os": {
+                                    "const": "freebsd"
+                                },
+                                "triplet": {
+                                    "const": "x86_64-unknown-freebsd11.1"
+                                }
+                            }
+                        }
+                    ]
                 }
             ],
             "title": "File"

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "type": "object",
+    "minProperties": 1,
     "propertyNames": {
         "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-(?:alpha[0-9]*|beta[0-9]*|rc[0-9]+|pre\\.(?:alpha|beta)))?$"
     },

--- a/schema.json
+++ b/schema.json
@@ -47,7 +47,8 @@
                     "pattern": "^[0-9A-Fa-f]{40}$"
                 },
                 "git-tree-sha256": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^[0-9A-Fa-f]{64}$"
                 },
                 "size": {
                     "type": "integer"

--- a/schema.json
+++ b/schema.json
@@ -67,6 +67,14 @@
                         ".exe",
                         ".gz",
                         ".zip"
+                    ],
+                    "allOf": [
+                        {
+                            "pattern": "^https://"
+                        },
+                        {
+                            "pattern": "\\.(?:dmg|exe|gz|zip)$"
+                        }
                     ]
                 },
                 "asc": {

--- a/schema.json
+++ b/schema.json
@@ -80,6 +80,9 @@
                             "pattern": "^https://[^/?#]+/"
                         },
                         {
+                            "pattern": "^https://\\S+$"
+                        },
+                        {
                             "pattern": "\\.(?:dmg|exe|tar\\.gz|zip)$"
                         }
                     ]


### PR DESCRIPTION
## Summary

This PR builds on #83.

This PR tightens `schema.json` with the approved validation constraints for `versions.json`.

It adds stricter validation for digest fields, Julia version strings, URL shape, PGP signature armor, positive sizes, non-empty/unique file arrays, top-level version entries, and selected cross-field consistency rules.

## Validation

- `jq empty schema.json`
- `npx -p ajv-cli@3.3.0 ajv compile -s schema.json`
- `npx -p ajv-cli@3.3.0 ajv -s schema.json -d /tmp/versionsjsonutil-live-*.json` against the live S3 `versions.json`
- `julia --project=. -e 'using Pkg; Pkg.test()'`

CC: @DilumAluthge

🤖 Generated by OpenAI Codex.
