### PR TITLE
Add an only-version input for targeted single-version updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,10 @@ on:
         description: "Ignore the deployed versions.json and rebuild everything from scratch"
         type: boolean
         default: false
+      only-version:
+        description: "Only add/update this one version (e.g. 1.13.0-rc3); everything else is carried over as-is"
+        type: string
+        default: ""
   push:
     branches:
       - main
@@ -95,7 +99,12 @@ jobs:
         run: |
           using VersionsJSONUtil
 
-          VersionsJSONUtil.main("versions.json")
+          only_version = "${{ inputs.only-version }}"
+
+          VersionsJSONUtil.main(
+              "versions.json";
+              only_version = isempty(only_version) ? nothing : only_version,
+          )
         shell: julia --project {0}
 
       - name: Diff against the deployed versions.json

--- a/src/VersionsJSONUtil.jl
+++ b/src/VersionsJSONUtil.jl
@@ -271,11 +271,18 @@ function delete_filedicts_for_url!(meta, version, url)
     return nothing
 end
 
-function main(out_path)
+function main(out_path; only_version = nothing)
     tags = get_tags()
     tag_versions = filter(x -> x !== nothing, [vnum_maybe(basename(t["ref"])) for t in tags])
 
     meta = load_seed(out_path)
+    if only_version !== nothing
+        version = VersionNumber(only_version)
+        version in tag_versions || error("$(version) is not a tag in the JuliaLang/julia repository")
+        # a missing seed would produce a versions.json containing only this version
+        isempty(meta) && error("refusing to run with only_version = $(version) without a seeded versions.json")
+        tag_versions = [version]
+    end
     number_urls_tried = 0
     number_urls_success = 0
     number_carried_over = 0


### PR DESCRIPTION
Adds an `only-version` text input to the Run workflow dialog. Give it one version (e.g. `1.13.0-rc3`) and the build downloads exactly that version's files and updates `versions.json` with exactly that version — every other seeded entry is carried over untouched, with no HEAD sweep over the rest of the grid. This makes the release-day update a targeted, fast run instead of a full pass over every tag.

Safety guards:
- errors if the given version is not a tag in JuliaLang/julia (catches typos before anything is touched)
- refuses to run when no seeded `versions.json` is present, since the result would contain only that one version

Left empty (or on push-triggered runs) the behavior is unchanged from `main`.

Tested locally against the currently deployed `versions.json` with `only_version = "1.13.0-rc3"`: it downloaded rc3's 14 files, the resulting file's only added key is `1.13.0-rc3` (byte-identical to what a full incremental run produces), and it passes the schema check and `test/more_tests.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)